### PR TITLE
Typo in the network name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ services:
 networks:
   default:
      external:
-       name: myhero_data_default
+       name: myherodata_default


### PR DESCRIPTION
The previous container created (myhero_data) creates network called myherodata_default, rather than myhero_data_default.